### PR TITLE
Update with-custom-font example

### DIFF
--- a/with-custom-font/App.js
+++ b/with-custom-font/App.js
@@ -1,37 +1,33 @@
 import * as Font from "expo-font";
-import * as SplashScreen from 'expo-splash-screen';
+import * as SplashScreen from "expo-splash-screen";
 import { Text, View } from "react-native";
-import { useEffect, useCallback } from "react";
+import { useCallback } from "react";
+
+// Keep the splash screen visible while we fetch resources
+SplashScreen.preventAutoHideAsync();
 
 export default function App() {
-  const [fontsLoaded] = Font.useFonts({
+  const [fontsLoaded, fontError] = Font.useFonts({
     "Inter-Black": require("./assets/fonts/Inter-Black.otf"),
     "Inter-SemiBoldItalic":
       "https://rsms.me/inter/font-files/Inter-SemiBoldItalic.otf?v=3.12",
   });
 
-  useEffect(() => {
-    async function prepare() {
-      await SplashScreen.preventAutoHideAsync();
-    }
-
-    prepare();
-  }, []);
-
   const onLayoutRootView = useCallback(async () => {
-    if (fontsLoaded) {
+    if (fontsLoaded || fontError) {
       await SplashScreen.hideAsync();
     }
-  }, [fontsLoaded]);
+  }, [fontsLoaded, fontError]);
 
-  if (!fontsLoaded) {
+  if (!fontsLoaded && !fontError) {
     return null;
   }
 
   return (
-    <View 
+    <View
       style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
-      onLayout={onLayoutRootView}>
+      onLayout={onLayoutRootView}
+    >
       <Text>Platform Default</Text>
       <Text style={{ fontFamily: "Inter-Black" }}>Inter Black</Text>
       <Text style={{ fontFamily: "Inter-SemiBoldItalic" }}>


### PR DESCRIPTION
## Improvements

There are 3 things that i want to improve.

### 1. Inconsistent style

Prettier was not applied to all lines of this example.

```diff
// line 2
- import * as SplashScreen from 'expo-splash-screen';
+ import * as SplashScreen from "expo-splash-screen";
```

### 2. Not recommended usage of `preventAutoHideAsync` method

According to the [SplashScreen Method](https://docs.expo.dev/versions/latest/sdk/splash-screen/#methods) section, `preventAutoHideAsync` method is recommended to be called in global scope without awaiting because otherwise this might be called too late.

However, in this example, `preventAutoHideAsync` is called inside of `useEffect` hook . So I updated this.

### 3. Unhandled error case
it might be helpful to use `fontError` that `useFonts` returns. Because errors can happen while fetching remote font.

## Reference
https://docs.expo.dev/develop/user-interface/fonts/#minimal-example